### PR TITLE
change data script check to stable/unstable

### DIFF
--- a/.github/workflows/(on push) data check.yml
+++ b/.github/workflows/(on push) data check.yml
@@ -8,18 +8,22 @@ jobs:
     name: Data Files
     runs-on: windows-2022
     env:
-      CONTINUOUS: EndlessSky-win64-continuous.zip
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 2
+    - name: install libs
+      run: |
+        python3 -m pip install Requests
+    - name: Get version & set env
+      run: python3 res/src/getversion.py
     - name: Download
-      run: gh release download -R endless-sky/endless-sky continuous -p ${{ env.CONTINUOUS }}
-    - name: Extract & prepare continuous
+      run: gh release download -R endless-sky/endless-sky ${{ env.ES_VERSION }} -p ${{ env.RELEASE }}
+    - name: Extract & prepare release
       run: |
         mkdir endless-sky
-        Expand-Archive ${{ env.CONTINUOUS }} -DestinationPath endless-sky -Force
+        Expand-Archive ${{ env.RELEASE }} -DestinationPath endless-sky -Force
         move .\myplugins .\endless-sky\plugins
     - name: Parse Datafiles
       run: "'.\\endless-sky\\Endless Sky.exe' -p"

--- a/res/src/getversion.py
+++ b/res/src/getversion.py
@@ -1,0 +1,23 @@
+import requests
+import os
+
+
+def get_version():
+	request = requests.get('https://github.com/endless-sky/endless-sky/raw/refs/heads/master/changelog')
+	with open('changelog.txt', 'wb') as changelog:
+		changelog.write(request.content) # downloading the changelog
+	with open('changelog.txt', 'r') as sourcefile:
+		onlineversion = 'v' + sourcefile.readline().replace('Version ', '').replace('\n', '') # result example: v0.10.10
+	releasev = 'EndlessSky-win64-' + onlineversion + '.zip '
+	env_file = os.getenv('GITHUB_ENV')
+	with open(env_file, "a") as envfile:
+		envfile.write("ES_VERSION=" + onlineversion + '\n')
+		envfile.write("RELEASE=" + releasev + '\n')
+
+
+def run():
+	get_version()
+
+
+if __name__ == "__main__":
+	run()


### PR DESCRIPTION
instead of a data script check with the continuous version, this change let it check with the latest stable/unstable version.
this is done due to possible script differences between stable/unstable and continuous (like the current missile homing change).